### PR TITLE
Activity privacy and invitation functionality

### DIFF
--- a/controllers/api/activity-routes.js
+++ b/controllers/api/activity-routes.js
@@ -1,6 +1,12 @@
 const sequelize = require("../../config/connection");
 const router = require("express").Router();
-const { Activity, User, Comment, Attendance } = require("../../models");
+const {
+  Activity,
+  User,
+  Comment,
+  Attendance,
+  Invitation,
+} = require("../../models");
 const { withAuth } = require("../../utils/auth");
 
 /* 
@@ -47,6 +53,13 @@ router.get("/", (req, res) => {
         model: User,
         through: Attendance,
         as: "attending",
+        attributes: ["id", "username"],
+      },
+      {
+        model: User,
+        through: Invitation,
+        as: "invited",
+        attributes: ["id", "username"],
       },
     ],
   };

--- a/controllers/api/index.js
+++ b/controllers/api/index.js
@@ -7,6 +7,7 @@ const userDietaryPrefRoutes = require("./user-dietary-pref-routes");
 const userInterestRoutes = require("./user-interest-routes");
 const interestRoutes = require("./interest-routes");
 const dietaryPrefRoutes = require("./dietaryPrefs-routes");
+const invitationRoutes = require("./invitation-routes");
 
 router.use("/users", userRoutes);
 router.use("/activities", activityRoutes);
@@ -15,5 +16,6 @@ router.use("/userDietaryPrefs", userDietaryPrefRoutes);
 router.use("/userInterests", userInterestRoutes);
 router.use("/interests", interestRoutes);
 router.use("/dietaryPrefs", dietaryPrefRoutes);
+router.use("/invitations", invitationRoutes);
 
 module.exports = router;

--- a/controllers/api/invitation-routes.js
+++ b/controllers/api/invitation-routes.js
@@ -64,7 +64,7 @@ router.get("/:id", (req, res) => {
 */
 router.post("/", (req, res) => {
   Invitation.create({
-    user_id: req.session.user_id || req.body.user_id,
+    user_id: req.body.user_id,
     activity_id: req.body.activity_id,
   })
     .then((dbInvitationData) => {

--- a/controllers/api/invitation-routes.js
+++ b/controllers/api/invitation-routes.js
@@ -1,0 +1,30 @@
+const router = require("express").Router();
+const { Invitation, User, Activity } = require("../../models");
+
+/* 
+    GET /api/invitations
+    Returns all invitations
+*/
+router.get("/", (req, res) => {
+  Invitation.findAll({
+    include: [
+      {
+        model: User,
+        foreignKey: "user_id",
+      },
+      {
+        model: Activity,
+        foreignKey: "activity_id",
+      },
+    ],
+  })
+    .then((dbInvitationData) => {
+      res.json(dbInvitationData);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json(err);
+    });
+});
+
+module.exports = router;

--- a/controllers/api/invitation-routes.js
+++ b/controllers/api/invitation-routes.js
@@ -10,6 +10,34 @@ router.get("/", (req, res) => {
     include: [
       {
         model: User,
+        attributes: ["id", "username"],
+        foreignKey: "user_id",
+      },
+      {
+        model: Activity,
+        attributes: ["id", "title"],
+        foreignKey: "activity_id",
+      },
+    ],
+  })
+    .then((dbInvitationData) => {
+      res.json(dbInvitationData);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json(err);
+    });
+});
+
+/* 
+    GET /api/invitations/:id
+*/
+router.get("/:id", (req, res) => {
+  Invitation.findOne({
+    where: { id: req.params.id },
+    include: [
+      {
+        model: User,
         foreignKey: "user_id",
       },
       {
@@ -19,6 +47,44 @@ router.get("/", (req, res) => {
     ],
   })
     .then((dbInvitationData) => {
+      if (!dbInvitationData) {
+        res.status(404).json({ message: "No invitation found with that ID" });
+      }
+      res.json(dbInvitationData);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json(err);
+    });
+});
+
+/* 
+    POST /api/invitations
+    CREATEs an invitation record
+*/
+router.post("/", (req, res) => {
+  Invitation.create({
+    user_id: req.session.user_id || req.body.user_id,
+    activity_id: req.body.activity_id,
+  })
+    .then((dbInvitationData) => {
+      res.json(dbInvitationData);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json(err);
+    });
+});
+
+/* 
+    DELETE /api/invitations/:id
+*/
+router.delete("/:id", (req, res) => {
+  Invitation.destroy({ where: { id: req.params.id } })
+    .then((dbInvitationData) => {
+      if (!dbInvitationData) {
+        res.status(404).json({ message: "No invitation with that ID" });
+      }
       res.json(dbInvitationData);
     })
     .catch((err) => {

--- a/controllers/homepage-routes.js
+++ b/controllers/homepage-routes.js
@@ -7,6 +7,7 @@ const {
   UserInterest,
   DietaryPref,
   Attendance,
+  Invitation,
 } = require("../models");
 const { sequelize } = require("../models/User");
 const { withAuth } = require("../utils/auth");
@@ -175,8 +176,27 @@ router.get("/activity/new", withAuth, (req, res) => {
 
 router.get("/activity/:id", withAuth, (req, res) => {
   Activity.findOne({
-    where: { id: req.params.id },
-    include: [{ model: User, attributes: ["id", "username"] }],
+    where: {
+      id: req.params.id,
+    },
+    include: [
+      {
+        model: User,
+        attributes: ["id", "username"],
+      },
+      {
+        model: User,
+        through: Invitation,
+        attributes: ["id", "username"],
+        as: "invited",
+      },
+      {
+        model: User,
+        through: Attendance,
+        attributes: ["id", "username"],
+        as: "attending",
+      },
+    ],
   })
     .then((dbActivityData) => {
       console.log(dbActivityData.get({ plain: true }));

--- a/models/Invitation.js
+++ b/models/Invitation.js
@@ -1,4 +1,5 @@
 const { Model, DataTypes } = require("sequelize");
+const sequelize = require("../config/connection");
 
 class Invitation extends Model {}
 

--- a/models/Invitation.js
+++ b/models/Invitation.js
@@ -35,3 +35,5 @@ Invitation.init(
     modelName: "invitation",
   }
 );
+
+module.exports = Invitation;

--- a/models/Invitation.js
+++ b/models/Invitation.js
@@ -1,0 +1,37 @@
+const { Model, DataTypes } = require("sequelize");
+
+class Invitation extends Model {}
+
+Invitation.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+      allowNull: false,
+    },
+    user_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: "user",
+        key: "id",
+      },
+    },
+    activity_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: "activity",
+        key: "id",
+      },
+    },
+  },
+  {
+    sequelize,
+    timestamps: false,
+    freezeTableName: true,
+    underscored: true,
+    modelName: "invitation",
+  }
+);

--- a/models/User.js
+++ b/models/User.js
@@ -56,6 +56,16 @@ User.init(
         );
         return updatedUserData;
       },
+      beforeBulkCreate(newUserData) {
+        newUserData.map((user) => {
+          user.dataValues.password = bcrypt.hashSync(
+            user.dataValues.password,
+            10
+          );
+          return user;
+        });
+        return newUserData;
+      },
     },
     sequelize,
     timestamps: false,

--- a/models/index.js
+++ b/models/index.js
@@ -6,6 +6,7 @@ const UserInterest = require("./UserInterest");
 const Activity = require("./Activity");
 const Attendance = require("./Attendance");
 const Comment = require("./Comment");
+const Invitation = require("./Invitation");
 
 /* 
     User - Dietary Preference
@@ -72,7 +73,7 @@ Interest.hasMany(UserInterest, {
 */
 User.hasMany(Activity, {
   foreignKey: "organizer_id",
-  as: "organizing"
+  as: "organizing",
 });
 
 Activity.belongsTo(User, {
@@ -143,6 +144,37 @@ Activity.belongsTo(Interest, {
   foreignKey: "interest_id",
 });
 
+/* 
+    Activty - User (invitation) 
+*/
+User.belongsToMany(Activity, {
+  through: Invitation,
+  as: "invitations",
+  foreignKey: "user_id",
+});
+
+Activity.belongsToMany(User, {
+  through: Invitation,
+  as: "invitations",
+  foreignKey: "activity_id",
+});
+
+Invitation.belongsTo(User, {
+  foreignKey: "user_id",
+});
+
+Invitation.belongsTo(Activity, {
+  foreignKey: "activity_id",
+});
+
+User.hasMany(Invitation, {
+  foreignKey: "user_id",
+});
+
+Activity.hasMany(Invitation, {
+  foreignKey: "user_id",
+});
+
 module.exports = {
   User,
   Activity,
@@ -152,4 +184,5 @@ module.exports = {
   UserInterest,
   DietaryPref,
   UserDietaryPref,
+  Invitation,
 };

--- a/models/index.js
+++ b/models/index.js
@@ -149,13 +149,13 @@ Activity.belongsTo(Interest, {
 */
 User.belongsToMany(Activity, {
   through: Invitation,
-  as: "invitations",
+  as: "invited",
   foreignKey: "user_id",
 });
 
 Activity.belongsToMany(User, {
   through: Invitation,
-  as: "invitations",
+  as: "invited",
   foreignKey: "activity_id",
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^5.0.1",
+        "bootstrap": "^5.1.3",
         "connect-session-sequelize": "^7.1.2",
         "dotenv": "^16.0.0",
         "express": "^4.17.2",
@@ -37,6 +38,16 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
+      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@types/debug": {
@@ -176,6 +187,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/bootstrap": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bootstrap"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.10.2"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",

--- a/public/javascript/delete-activity.js
+++ b/public/javascript/delete-activity.js
@@ -1,5 +1,5 @@
 document.addEventListener("DOMContentLoaded", () => {
-  const $modals = document.querySelectorAll(".modal");
+  const $modals = document.querySelectorAll("#confirm-delete-modal");
   const modalInsts = M.Modal.init($modals);
 });
 

--- a/public/javascript/invite.js
+++ b/public/javascript/invite.js
@@ -1,0 +1,28 @@
+const $inviteForm = document.querySelector("#inviteForm");
+const $inviteSelect = document.querySelector("#inviteSelect");
+let inviteSelectInst;
+
+document.addEventListener("DOMContentLoaded", () => {
+  const $inviteModal = document.querySelectorAll("#inviteModal");
+  console.log($inviteModal);
+  const inviteModalInst = M.Modal.init($inviteModal, {
+    preventScrolling: false,
+  });
+
+  populateUsers().then(() => {
+    inviteSelectInst = M.FormSelect.init($inviteSelect);
+  });
+});
+
+const populateUsers = async () => {
+  return await fetch("/api/users")
+    .then((response) => response.json())
+    .then((apiUserData) => {
+      apiUserData.forEach((user) => {
+        let $option = document.createElement("option");
+        $option.value = user.id;
+        $option.textContent = user.username;
+        $inviteSelect.appendChild($option);
+      });
+    });
+};

--- a/public/javascript/invite.js
+++ b/public/javascript/invite.js
@@ -4,7 +4,6 @@ let inviteSelectInst;
 
 document.addEventListener("DOMContentLoaded", () => {
   const $inviteModal = document.querySelectorAll("#inviteModal");
-  console.log($inviteModal);
   const inviteModalInst = M.Modal.init($inviteModal, {
     preventScrolling: false,
   });
@@ -12,6 +11,10 @@ document.addEventListener("DOMContentLoaded", () => {
   populateUsers().then(() => {
     inviteSelectInst = M.FormSelect.init($inviteSelect);
   });
+
+  document
+    .querySelector("#sendInvitationsButton")
+    .addEventListener("click", sendInvitationsButtonHandler);
 });
 
 const populateUsers = async () => {
@@ -25,4 +28,35 @@ const populateUsers = async () => {
         $inviteSelect.appendChild($option);
       });
     });
+};
+
+const sendInvitationsButtonHandler = (event) => {
+  const values = inviteSelectInst.getSelectedValues();
+
+  if (values[0] === "") {
+    console.log("empty");
+    return;
+  }
+
+  const activity_id = location.toString().split("/")[
+    location.toString().split("/").length - 1
+  ];
+
+  values.forEach((value) => {
+    fetch("/api/invitations", {
+      method: "POST",
+      body: JSON.stringify({
+        user_id: value,
+        activity_id: activity_id,
+      }),
+      headers: { "Content-Type": "application/json" },
+    })
+      .then((response) => response.json())
+      .then((apiInvitationData) => console.log(apiInvitationData))
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+
+  console.log(values);
 };

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -16,4 +16,7 @@ module.exports = {
   is_organizer: (user_id, activity_id) => {
     return user_id === activity_id;
   },
+  is_invited: (user_id, attending) => {
+    return attending.find((i) => i.id === user_id);
+  },
 };

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -16,7 +16,13 @@ module.exports = {
   is_organizer: (user_id, activity_id) => {
     return user_id === activity_id;
   },
-  is_invited: (user_id, attending) => {
+  is_invited: (user_id, invited) => {
+    return invited.find((i) => i.id === user_id);
+  },
+  is_attending: (user_id, attending) => {
+    if (!attending) {
+      return false;
+    }
     return attending.find((i) => i.id === user_id);
   },
 };

--- a/views/activity.handlebars
+++ b/views/activity.handlebars
@@ -22,6 +22,11 @@
               class="btn modal-trigger"
               data-target="confirm-delete-modal"
             >Delete</button>
+            <button
+              id="inviteButton"
+              class="btn modal-trigger"
+              data-target="inviteModal"
+            >Invite</button>
           {{else}}
             <a class="btn" href="#">Attend</a>
           {{/if}}
@@ -45,6 +50,28 @@
     </div>
   </div>
 
+  <!-- Invite Modal -->
+  <div id="inviteModal" class="modal">
+    <div class="modal-content" style="min-height: 50vh;">
+      <h4>Invite Friends</h4>
+      <form id="inviteForm">
+        <div class="input-field col s12">
+          <select id="inviteSelect" multiple>
+            <option value="" disabled selected>Select people to invite</option>
+          </select>
+          <label>Invitees</label>
+        </div>
+      </form>
+    </div>
+    <div class="modal-footer">
+      <a
+        id="sendInvitationsButton"
+        class="modal-close waves-effect waves-green btn-flat"
+      >Send</a>
+      <a class="modal-close waves-effect red white-text btn-flat">Cancel</a>
+    </div>
+  </div>
+
   <!-- Modal Structure -->
   <div id="modal1" class="modal">
     <div class="modal-content">
@@ -65,4 +92,7 @@
 <div class="container">
 </div>
 
-<script src="/javascript/delete-activity.js"></script>
+{{#if (is_organizer user_id activity.user.id)}}
+  <script src="/javascript/delete-activity.js"></script>
+  <script src="/javascript/invite.js"></script>
+{{/if}}

--- a/views/activity.handlebars
+++ b/views/activity.handlebars
@@ -31,8 +31,23 @@
               data-target="inviteModal"
             >Invite</button>
           {{else}}
-            {{#if activity.is_private}}<span>This activity is private.</span>{{else}}
-              <a class="btn" href="#">Attend</a>
+            {{#if activity.is_private}}
+              {{#unless (is_invited user_id activity.invited)}}
+                <span>This activity is private.</span>
+              {{/unless}}
+              {{#if (is_invited user_id activity.invited)}}
+                {{#if (is_attending user_id activity.attending)}}
+                  <a class="btn" href="#">Decline</a>
+                {{else}}
+                  <a class="btn" href="#">Attend</a>
+                {{/if}}
+              {{/if}}
+            {{else}}
+              {{#if (is_attending user_id activity.attending)}}
+                <a class="btn" href="#">Decline</a>
+              {{else}}
+                <a class="btn" href="#">Attend</a>
+               {{/if}}
             {{/if}}
           {{/if}}
         </div>

--- a/views/activity.handlebars
+++ b/views/activity.handlebars
@@ -7,9 +7,12 @@
         <div class="card-content">
           <span class="card-title">{{activity.title}}</span>
           <p>{{activity.description}}</p>
-          <p>{{activity.location}}</p>
           <p>{{activity.user.username}}</p>
+          {{#if activity.is_private}}{{else}}
+            <p>{{activity.location}}</p>
+          {{/if}}
         </div>
+        
         <div class="card-action">
           {{#if (is_organizer user_id activity.user.id)}}
             <a
@@ -28,69 +31,53 @@
               data-target="inviteModal"
             >Invite</button>
           {{else}}
-            <a class="btn" href="#">Attend</a>
+            {{#if activity.is_private}}<span>This activity is private.</span>{{else}}
+              <a class="btn" href="#">Attend</a>
+            {{/if}}
           {{/if}}
         </div>
       </div>
     </div>
   </div>
 
-  <!-- Confirm Delete Modal -->
-  <div id="confirm-delete-modal" class="modal">
-    <div class="modal-content">
-      <h4>Confirm Deleting Activity</h4>
-      <p>Are you sure you want to delete activity "{{activity.title}}"?</p>
+  {{#if (is_organizer user_id activity.organizer_id)}}
+    <!-- Confirm Delete Modal -->
+    <div id="confirm-delete-modal" class="modal">
+      <div class="modal-content">
+        <h4>Confirm Deleting Activity</h4>
+        <p>Are you sure you want to delete activity "{{activity.title}}"?</p>
+      </div>
+      <div class="modal-footer">
+        <a
+          id="confirmDeleteButton"
+          class="modal-close waves-effect waves-red btn red"
+        >Delete</a>
+        <a class="modal-close waves-effect waves-green btn-flat">Cancel</a>
+      </div>
     </div>
-    <div class="modal-footer">
-      <a
-        id="confirmDeleteButton"
-        class="modal-close waves-effect waves-red btn red"
-      >Delete</a>
-      <a class="modal-close waves-effect waves-green btn-flat">Cancel</a>
-    </div>
-  </div>
 
-  <!-- Invite Modal -->
-  <div id="inviteModal" class="modal">
-    <div class="modal-content" style="min-height: 50vh;">
-      <h4>Invite Friends</h4>
-      <form id="inviteForm">
-        <div class="input-field col s12">
-          <select id="inviteSelect" multiple>
-            <option value="" disabled selected>Select people to invite</option>
-          </select>
-          <label>Invitees</label>
-        </div>
-      </form>
+    <!-- Invite Modal -->
+    <div id="inviteModal" class="modal">
+      <div class="modal-content" style="min-height: 50vh;">
+        <h4>Invite Friends</h4>
+        <form id="inviteForm">
+          <div class="input-field col s12">
+            <select id="inviteSelect" multiple>
+              <option value="" disabled selected>Select people to invite</option>
+            </select>
+            <label>Invitees</label>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <a
+          id="sendInvitationsButton"
+          class="modal-close waves-effect waves-green btn-flat"
+        >Send</a>
+        <a class="modal-close waves-effect red white-text btn-flat">Cancel</a>
+      </div>
     </div>
-    <div class="modal-footer">
-      <a
-        id="sendInvitationsButton"
-        class="modal-close waves-effect waves-green btn-flat"
-      >Send</a>
-      <a class="modal-close waves-effect red white-text btn-flat">Cancel</a>
-    </div>
-  </div>
-
-  <!-- Modal Structure -->
-  <div id="modal1" class="modal">
-    <div class="modal-content">
-      <h4>
-        {{! confirm attendance }}
-      </h4>
-      <p></p>
-    </div>
-    <div class="modal-footer">
-      <a
-        href="#!"
-        class="modal-action modal-close waves-effect waves-green btn-flat"
-      >Attend</a>
-    </div>
-  </div>
-</div>
-<!-- TODO: add attendee-->
-<div class="container">
-</div>
+  {{/if}}
 
 {{#if (is_organizer user_id activity.user.id)}}
   <script src="/javascript/delete-activity.js"></script>

--- a/views/homepage.handlebars
+++ b/views/homepage.handlebars
@@ -13,6 +13,7 @@
             {{#each pastOrgActivities as |activity|}}
               {{> activity-card activity}}
             {{/each}}
+          </div>
           {{else}}
           <p>You haven't organized any events in the past.</p>
         </div>
@@ -22,6 +23,7 @@
           {{/if}}
           </div>
         </div>
+      </div>
     <div class="col s12 m6">
       <div class="card">
         <div class="card-content">


### PR DESCRIPTION
Restricts buttons/actions on activity view based on invitation, attending, and organizer status.

﻿- adds invitation model
- Add invitation associations
- import sequelize
- uses invitation routes for /invitations
- adds invitiation-routes.js and GET route for all invitations
- adds post and delete routes to invitation-routes
- add invite modal, include scripts
- adds invitation functionality to activity page where user is organizer
- updates query selector to choose modal by id
- update post route to use body.user_id for user_id, not req.session.user_id
- enables sending invitations to user by adding invitation to database
- adds is_invited helper function
- update homepage, missing divs
- npm instasll
- add protection from users seeing buttons based on invitation, attnedance, and organizer_id status
- updates is_invited and is_attending helper functions
- add beforeBulkCreate hook to hash password before storing
- updates through table name in association
- includes invitation and attendance when rendering route /activity/<activity_id>
- updates GET /api/activities to include invitation and attendance data
